### PR TITLE
Add support for Lite API

### DIFF
--- a/ipinfo_django/middleware.py
+++ b/ipinfo_django/middleware.py
@@ -20,9 +20,7 @@ class IPinfoMiddleware:
 
         ipinfo_token = getattr(settings, "IPINFO_TOKEN", None)
         ipinfo_settings = getattr(settings, "IPINFO_SETTINGS", {})
-        self.ip_selector = getattr(
-            settings, "IPINFO_IP_SELECTOR", DefaultIPSelector()
-        )
+        self.ip_selector = getattr(settings, "IPINFO_IP_SELECTOR", DefaultIPSelector())
         self.ipinfo = ipinfo.getHandler(ipinfo_token, **ipinfo_settings)
 
     def __call__(self, request):
@@ -34,7 +32,7 @@ class IPinfoMiddleware:
                 request.ipinfo = self.ipinfo.getDetails(
                     self.ip_selector.get_ip(request)
                 )
-        except Exception as exc:
+        except Exception:
             request.ipinfo = None
             LOGGER.error(traceback.format_exc())
 
@@ -57,9 +55,7 @@ class IPinfoAsyncMiddleware:
 
         ipinfo_token = getattr(settings, "IPINFO_TOKEN", None)
         ipinfo_settings = getattr(settings, "IPINFO_SETTINGS", {})
-        self.ip_selector = getattr(
-            settings, "IPINFO_IP_SELECTOR", DefaultIPSelector()
-        )
+        self.ip_selector = getattr(settings, "IPINFO_IP_SELECTOR", DefaultIPSelector())
         self.ipinfo = ipinfo.getHandlerAsync(ipinfo_token, **ipinfo_settings)
 
     def __call__(self, request):
@@ -83,3 +79,23 @@ class IPinfoAsyncMiddleware:
 
     def is_bot(self, request):
         return is_bot(request)
+
+
+class IPinfoLiteMiddleware(IPinfoMiddleware):
+    def __init__(self, get_response):
+        super().__init__(get_response=get_response)
+
+        ipinfo_token = getattr(settings, "IPINFO_TOKEN", None)
+        ipinfo_settings = getattr(settings, "IPINFO_SETTINGS", {})
+        self.ipinfo = ipinfo.getHandlerLite(ipinfo_token, **ipinfo_settings)
+
+
+class IPinfoAsyncLiteMiddleware(IPinfoAsyncMiddleware):
+    sync_capable = False
+    async_capable = True
+
+    def __init__(self, get_response):
+        super().__init__(get_response=get_response)
+        ipinfo_token = getattr(settings, "IPINFO_TOKEN", None)
+        ipinfo_settings = getattr(settings, "IPINFO_SETTINGS", {})
+        self.ipinfo = ipinfo.getHandlerAsyncLite(ipinfo_token, **ipinfo_settings)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     author_email="support@ipinfo.io",
     license="Apache License 2.0",
     packages=["ipinfo_django", "ipinfo_django.ip_selector"],
-    install_requires=["django", "ipinfo==4.2.1"],
+    install_requires=["django", "ipinfo>=5.2.0"],
     zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.fixture
+def ipinfo_middleware(settings):
+    settings.MIDDLEWARE = [
+        "ipinfo_django.middleware.IPinfoMiddleware",
+    ]
+
+
+@pytest.fixture
+def ipinfo_async_middleware(settings):
+    settings.MIDDLEWARE = [
+        "ipinfo_django.middleware.IPinfoAsyncMiddleware",
+    ]
+
+
+@pytest.fixture
+def ipinfo_lite_middleware(settings):
+    settings.MIDDLEWARE = [
+        "ipinfo_django.middleware.IPinfoLiteMiddleware",
+    ]
+
+
+@pytest.fixture
+def ipinfo_async_lite_middleware(settings):
+    settings.MIDDLEWARE = [
+        "ipinfo_django.middleware.IPinfoAsyncLiteMiddleware",
+    ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,8 +3,4 @@ SECRET_KEY = "FOR-TESTING-ONLY"
 
 ROOT_URLCONF = "tests.urls"
 
-MIDDLEWARE = [
-    "ipinfo_django.middleware.IPinfoAsyncMiddleware",
-]
-
 USE_TZ = False

--- a/tests/test_async_lite_middleware.py
+++ b/tests/test_async_lite_middleware.py
@@ -1,0 +1,43 @@
+from http import HTTPStatus
+from unittest import mock
+
+import pytest
+from ipinfo.details import Details
+
+
+@pytest.mark.asyncio
+async def test_middleware_appends_ip_info(async_client, ipinfo_async_lite_middleware):
+    with mock.patch("ipinfo.AsyncHandlerLite.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
+        res = await async_client.get("/test_view/")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 127.0.0.1" in res.content
+
+
+@pytest.mark.asyncio
+async def test_middleware_filters(async_client, ipinfo_async_lite_middleware):
+    res = await async_client.get("/test_view/", USER_AGENT="some bot")
+    assert res.status_code == HTTPStatus.OK
+    assert b"Request filtered." in res.content
+
+
+@pytest.mark.asyncio
+async def test_middleware_behind_proxy(async_client, ipinfo_async_lite_middleware):
+    with mock.patch("ipinfo.AsyncHandlerLite.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "93.44.186.197"})
+        res = await async_client.get("/test_view/", X_FORWARDED_FOR="93.44.186.197")
+
+        mocked_getDetails.assert_called_once_with("93.44.186.197")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 93.44.186.197" in res.content
+
+
+@pytest.mark.asyncio
+async def test_middleware_not_behind_proxy(async_client, ipinfo_async_lite_middleware):
+    with mock.patch("ipinfo.AsyncHandlerLite.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
+        res = await async_client.get("/test_view/")
+
+        mocked_getDetails.assert_called_once_with("127.0.0.1")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 127.0.0.1" in res.content

--- a/tests/test_async_middleware.py
+++ b/tests/test_async_middleware.py
@@ -6,7 +6,7 @@ from ipinfo.details import Details
 
 
 @pytest.mark.asyncio
-async def test_middleware_appends_ip_info(async_client):
+async def test_middleware_appends_ip_info(async_client, ipinfo_async_middleware):
     with mock.patch("ipinfo.AsyncHandler.getDetails") as mocked_getDetails:
         mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
         res = await async_client.get("/test_view/")
@@ -15,19 +15,17 @@ async def test_middleware_appends_ip_info(async_client):
 
 
 @pytest.mark.asyncio
-async def test_middleware_filters(async_client):
+async def test_middleware_filters(async_client, ipinfo_async_middleware):
     res = await async_client.get("/test_view/", USER_AGENT="some bot")
     assert res.status_code == HTTPStatus.OK
     assert b"Request filtered." in res.content
 
 
 @pytest.mark.asyncio
-async def test_middleware_behind_proxy(async_client):
+async def test_middleware_behind_proxy(async_client, ipinfo_async_middleware):
     with mock.patch("ipinfo.AsyncHandler.getDetails") as mocked_getDetails:
         mocked_getDetails.return_value = Details({"ip": "93.44.186.197"})
-        res = await async_client.get(
-            "/test_view/", X_FORWARDED_FOR="93.44.186.197"
-        )
+        res = await async_client.get("/test_view/", X_FORWARDED_FOR="93.44.186.197")
 
         mocked_getDetails.assert_called_once_with("93.44.186.197")
         assert res.status_code == HTTPStatus.OK
@@ -35,7 +33,7 @@ async def test_middleware_behind_proxy(async_client):
 
 
 @pytest.mark.asyncio
-async def test_middleware_not_behind_proxy(async_client):
+async def test_middleware_not_behind_proxy(async_client, ipinfo_async_middleware):
     with mock.patch("ipinfo.AsyncHandler.getDetails") as mocked_getDetails:
         mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
         res = await async_client.get("/test_view/")

--- a/tests/test_lite_middleware.py
+++ b/tests/test_lite_middleware.py
@@ -1,0 +1,38 @@
+from http import HTTPStatus
+from unittest import mock
+
+from ipinfo.details import Details
+
+
+def test_middleware_appends_ip_info(client, ipinfo_lite_middleware):
+    with mock.patch("ipinfo.HandlerLite.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
+        res = client.get("/test_view/")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 127.0.0.1" in res.content
+
+
+def test_middleware_filters(client, ipinfo_lite_middleware):
+    res = client.get("/test_view/", HTTP_USER_AGENT="some bot")
+    assert res.status_code == HTTPStatus.OK
+    assert b"Request filtered." in res.content
+
+
+def test_middleware_behind_proxy(client, ipinfo_lite_middleware):
+    with mock.patch("ipinfo.HandlerLite.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "93.44.186.197"})
+        res = client.get("/test_view/", HTTP_X_FORWARDED_FOR="93.44.186.197")
+
+        mocked_getDetails.assert_called_once_with("93.44.186.197")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 93.44.186.197" in res.content
+
+
+def test_middleware_not_behind_proxy(client, ipinfo_lite_middleware):
+    with mock.patch("ipinfo.HandlerLite.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
+        res = client.get("/test_view/")
+
+        mocked_getDetails.assert_called_once_with("127.0.0.1")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 127.0.0.1" in res.content

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,38 @@
+from http import HTTPStatus
+from unittest import mock
+
+from ipinfo.details import Details
+
+
+def test_middleware_appends_ip_info(client, ipinfo_middleware):
+    with mock.patch("ipinfo.Handler.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
+        res = client.get("/test_view/")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 127.0.0.1" in res.content
+
+
+def test_middleware_filters(client, ipinfo_middleware):
+    res = client.get("/test_view/", HTTP_USER_AGENT="some bot")
+    assert res.status_code == HTTPStatus.OK
+    assert b"Request filtered." in res.content
+
+
+def test_middleware_behind_proxy(client, ipinfo_middleware):
+    with mock.patch("ipinfo.Handler.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "93.44.186.197"})
+        res = client.get("/test_view/", HTTP_X_FORWARDED_FOR="93.44.186.197")
+
+        mocked_getDetails.assert_called_once_with("93.44.186.197")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 93.44.186.197" in res.content
+
+
+def test_middleware_not_behind_proxy(client, ipinfo_middleware):
+    with mock.patch("ipinfo.Handler.getDetails") as mocked_getDetails:
+        mocked_getDetails.return_value = Details({"ip": "127.0.0.1"})
+        res = client.get("/test_view/")
+
+        mocked_getDetails.assert_called_once_with("127.0.0.1")
+        assert res.status_code == HTTPStatus.OK
+        assert b"For testing: 127.0.0.1" in res.content

--- a/tox.ini
+++ b/tox.ini
@@ -5,17 +5,16 @@ envlist =
     py3.10-django{40}
 
 [testenv]
-commands = pytest {posargs}
-passenv = PYTHONPATH
+commands = pytest {posargs:tests/}
+setenv =
+    DJANGO_SETTINGS_MODULE = tests.settings
+    PYTHONPATH = {toxinidir}
+deps = requests
 
 [testenv:py3.10-django32]
-commands = pytest tests/test_async_middleware.py
+commands = pytest tests
 deps = -rrequirements/py310-django32.txt
 
 [testenv:py3.10-django40]
-commands = pytest tests/test_async_middleware.py
+commands = pytest tests
 deps = -rrequirements/py310-django40.txt
-
-[pytest]
-DJANGO_SETTINGS_MODULE = tests.settings
-python_files = test_*.py


### PR DESCRIPTION
Similar approach to other libraries. I added `IPinfoLiteMiddleware` and `IPinfoAsyncLiteMiddleware` that the same functionality as the previous middlewares.

I had to bump the `ipinfo` library version in `setup.py` as that's the first release that ships the Lite API handlers.

I made some changes to `tox` config as it wasn't working. Tests have been reworked too to use fixtures to customize which middlewares are set in the Django test configs, this way we can test all the middlewares. Previously only the async one was tested as that was hardcoded in `tests/settings.py`.